### PR TITLE
Added Parent Name In Animations

### DIFF
--- a/AsepriteImporter/Editor/AseFileImporter.cs
+++ b/AsepriteImporter/Editor/AseFileImporter.cs
@@ -142,7 +142,7 @@ namespace AsepriteImporter
             foreach (var animation in animations)
             {
                 AnimationClip animationClip = new AnimationClip();
-                animationClip.name = animation.TagName;
+                animationClip.name = name + "_" + animation.TagName;
                 animationClip.frameRate = 25;
 
                 AseFileAnimationSettings importSettings = GetAnimationSettingFor(animSettings, animation);


### PR DESCRIPTION
Added parent's name in the animations to help differentiate multiple animation tags of the same name. 

Ex:
Before this change Player and Orc ASE files with animation tags run and idle export as:
run.anim
run.anim
idle.anim
idle.anim

After this change:
Player_run.anim
Player_idle.anim
Enemy_run.anim
Enemy_idle.anim