### PR TITLE
Changed GetFileName to remove the file extension. This allows files w…

### DIFF
--- a/Editor/AseFileImporter.cs
+++ b/Editor/AseFileImporter.cs
@@ -118,7 +118,9 @@ namespace AsepriteImporter
         private string GetFileName(string assetPath)
         {
             string[] parts = assetPath.Split('/');
-            return parts[parts.Length - 1].Replace(".ase", "");
+            string filename = parts[parts.Length - 1];
+
+            return filename.Substring(0, filename.LastIndexOf('.'));
         }
 
         private static AseFile ReadAseFile(string assetPath)


### PR DESCRIPTION
…ith the extension ".aseprite" to be properly renamed rather than have only ".ase" portion removed.

Example: Before a file named "File.aseprite" would return "Fileprite" rather than "File"