### PR TITLE
Added multi-object editing on inspector

### DIFF
--- a/Editor/AseFileImporterEditor.cs
+++ b/Editor/AseFileImporterEditor.cs
@@ -5,7 +5,7 @@ using UnityEditor;
 
 namespace AsepriteImporter
 {
-    [CustomEditor(typeof(AseFileImporter))]
+    [CustomEditor(typeof(AseFileImporter)), CanEditMultipleObjects]
     public class AseFileImporterEditor : ScriptedImporterEditor
     {
 


### PR DESCRIPTION
This change allows the user to edit 2+ sprites at the same time in the Unity Inspector

![Screen Shot 2020-01-28 at 17 32 31](https://user-images.githubusercontent.com/7061445/73302939-3e397500-41f4-11ea-8d7d-a333f66f2ff2.png)
