### PR TITLE
New feature: Bind Animations to UI Images

### DIFF
--- a/Editor/AseFileImporter.cs
+++ b/Editor/AseFileImporter.cs
@@ -17,6 +17,12 @@ namespace AsepriteImporter
         LayerToSprite
     }
 
+    public enum AseEditorBindType
+    {
+        SpriteRenderer,
+        UIImage
+    }
+
     [ScriptedImporter(1, new []{ "ase", "aseprite" })]
     public class AseFileImporter : ScriptedImporter
     {
@@ -24,7 +30,7 @@ namespace AsepriteImporter
         [SerializeField] public AseFileAnimationSettings[] animationSettings;
         [SerializeField] public Texture2D atlas;
         [SerializeField] public AseFileImportType importType;
-        [SerializeField] public bool bindToImage;
+        [SerializeField] public AseEditorBindType bindType;
 
         public override void OnImportAsset(AssetImportContext ctx)
         {
@@ -173,9 +179,18 @@ namespace AsepriteImporter
 
 
                 EditorCurveBinding editorBinding = new EditorCurveBinding();
-                editorBinding.type = bindToImage ? typeof(Image) : typeof(SpriteRenderer);
                 editorBinding.path = "";
                 editorBinding.propertyName = "m_Sprite";
+
+                switch (bindType)
+                {
+                    case AseEditorBindType.SpriteRenderer:
+                        editorBinding.type = typeof(SpriteRenderer);
+                        break;
+                    case AseEditorBindType.UIImage:
+                        editorBinding.type = typeof(Image);
+                        break;
+                }
 
 
                 int length = animation.FrameTo - animation.FrameFrom + 1;

--- a/Editor/AseFileImporter.cs
+++ b/Editor/AseFileImporter.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
 using UnityEditor.Experimental.AssetImporters;
 using System.IO;
 using Aseprite;
@@ -23,6 +24,7 @@ namespace AsepriteImporter
         [SerializeField] public AseFileAnimationSettings[] animationSettings;
         [SerializeField] public Texture2D atlas;
         [SerializeField] public AseFileImportType importType;
+        [SerializeField] public bool bindToImage;
 
         public override void OnImportAsset(AssetImportContext ctx)
         {
@@ -170,10 +172,10 @@ namespace AsepriteImporter
                 importSettings.about = GetAnimationAbout(animation);
 
 
-                EditorCurveBinding spriteBinding = new EditorCurveBinding();
-                spriteBinding.type = typeof(SpriteRenderer);
-                spriteBinding.path = "";
-                spriteBinding.propertyName = "m_Sprite";
+                EditorCurveBinding editorBinding = new EditorCurveBinding();
+                editorBinding.type = bindToImage ? typeof(Image) : typeof(SpriteRenderer);
+                editorBinding.path = "";
+                editorBinding.propertyName = "m_Sprite";
 
 
                 int length = animation.FrameTo - animation.FrameFrom + 1;
@@ -213,7 +215,7 @@ namespace AsepriteImporter
                 spriteKeyFrames[spriteKeyFrames.Length - 1] = lastFrame;
 
 
-                AnimationUtility.SetObjectReferenceCurve(animationClip, spriteBinding, spriteKeyFrames);
+                AnimationUtility.SetObjectReferenceCurve(animationClip, editorBinding, spriteKeyFrames);
                 AnimationClipSettings settings = AnimationUtility.GetAnimationClipSettings(animationClip);
 
                 switch (animation.Animation)

--- a/Editor/AseFileImporterEditor.cs
+++ b/Editor/AseFileImporterEditor.cs
@@ -83,6 +83,8 @@ namespace AsepriteImporter
 
                 EditorGUILayout.PropertyField(serializedObject.FindProperty(textureSettings + "generatePhysics"));
 
+                EditorGUILayout.PropertyField(serializedObject.FindProperty("bindToImage"));
+
 
                 EditorGUILayout.Space();
 

--- a/Editor/AseFileImporterEditor.cs
+++ b/Editor/AseFileImporterEditor.cs
@@ -83,8 +83,15 @@ namespace AsepriteImporter
 
                 EditorGUILayout.PropertyField(serializedObject.FindProperty(textureSettings + "generatePhysics"));
 
-                EditorGUILayout.PropertyField(serializedObject.FindProperty("bindToImage"));
+                var editorBindingProperty = serializedObject.FindProperty("bindType");
+                var editorBinding = (AseEditorBindType) editorBindingProperty.intValue;
 
+                EditorGUI.BeginChangeCheck();
+                editorBinding = (AseEditorBindType) EditorGUILayout.EnumPopup("Component to Bind", editorBinding);
+                if (EditorGUI.EndChangeCheck())
+                {
+                    editorBindingProperty.intValue = (int) editorBinding;
+                }
 
                 EditorGUILayout.Space();
 


### PR DESCRIPTION
This adds the ability to import animations to other renderers than just the SpriteRenderer. Currently it supports UI Images, since that's the only other Sprite consumer that I'm aware of, but it should be easy to extend to other use cases.

Wanted to add this because I have a project right now that's both pixel perfect and entirely made in the UI space; hopefully others find it useful too.