### PR TITLE
Added transparent tile removal and better transparency options

### DIFF
--- a/Editor/AseFileImporterEditor.cs
+++ b/Editor/AseFileImporterEditor.cs
@@ -24,7 +24,6 @@ namespace AsepriteImporter
             foldoutStates.Clear();
         }
 
-
         public override void OnInspectorGUI()
         {
             serializedObject.Update();
@@ -45,21 +44,19 @@ namespace AsepriteImporter
                     importTypeProperty.intValue = importType;
                 }
 
-                var transparentColorMask = serializedObject.FindProperty(textureSettings + "transparentMask");
+                var transparencyMode = serializedObject.FindProperty(textureSettings + "transparencyMode");
                 var transparentColor = serializedObject.FindProperty(textureSettings + "transparentColor");
 
-                Rect lastRect = GUILayoutUtility.GetLastRect();
-                Rect resetButton = new Rect(EditorGUIUtility.labelWidth + 50,
-                    lastRect.y + EditorGUIUtility.singleLineHeight, 60, 18);
-                if (GUI.Button(resetButton, "Reset"))
+                EditorGUILayout.PropertyField(transparencyMode);
+                if (transparencyMode.intValue == (int)TransparencyMode.Mask)
                 {
-                    transparentColor.colorValue = Color.magenta;
-                }
-
-                EditorGUILayout.PropertyField(transparentColorMask);
-                if (transparentColorMask.boolValue)
-                {
+                    EditorGUILayout.BeginHorizontal();
                     EditorGUILayout.PropertyField(transparentColor);
+                    if (GUILayout.Button("Reset"))
+                    {
+                        transparentColor.colorValue = Color.magenta;
+                    }
+                    EditorGUILayout.EndHorizontal();
                 }
 
                 EditorGUILayout.PropertyField(serializedObject.FindProperty(textureSettings + "pixelsPerUnit"));
@@ -161,6 +158,7 @@ namespace AsepriteImporter
                     EditorGUILayout.PropertyField(serializedObject.FindProperty(textureSettings + "tilePadding"));
                     EditorGUILayout.PropertyField(serializedObject.FindProperty(textureSettings + "tileOffset"));
                     PivotPopup("Tile Pivot");
+                    EditorGUILayout.PropertyField(serializedObject.FindProperty("emptyTileBehaviour"), new GUIContent("Empty Tile Behaviour", "Behavior for empty tiles:\nKeep - Keep empty tiles\nIndex - Remove empty tiles, but still index them\nRemove - Remove empty tiles completely"));
 
                     EditorGUI.indentLevel--;
                 }

--- a/Editor/AseFileTextureSettings.cs
+++ b/Editor/AseFileTextureSettings.cs
@@ -11,13 +11,20 @@ namespace AsepriteImporter
         Y
     }
 
+    public enum TransparencyMode
+    {
+        Disabled,
+        Alpha,
+        Mask
+    }
+
     [System.Serializable]
     public class AseFileTextureSettings
     {
         [SerializeField] public TextureImporterType textureType = TextureImporterType.Sprite;
         [SerializeField] public int pixelsPerUnit = 32;
         [SerializeField] public MirrorOption mirror = MirrorOption.None;
-        [SerializeField] public bool transparentMask = false;
+        [SerializeField] public TransparencyMode transparencyMode = TransparencyMode.Disabled;
         [SerializeField] public Color transparentColor = Color.magenta;
         [SerializeField] public SpriteMeshType meshType = SpriteMeshType.Tight;
         [Range(0, 32)] [SerializeField] public uint extrudeEdges = 1;

--- a/Editor/SpriteAtlasBuilder.cs
+++ b/Editor/SpriteAtlasBuilder.cs
@@ -55,7 +55,7 @@ namespace AsepriteImporter
             return flipped;
         }
 
-        public Texture2D GenerateAtlas(Texture2D[] sprites, out SpriteImportData[] spriteData, bool mask,
+        public Texture2D GenerateAtlas(Texture2D[] sprites, out SpriteImportData[] spriteData, TransparencyMode transparencyMode,
             bool baseTwo = true)
         {
             var cols = sprites.Length;
@@ -96,7 +96,7 @@ namespace AsepriteImporter
             cols = (int) Math.Ceiling(spriteCount / divider);
             rows = (int) Math.Ceiling(spriteCount / cols);
 
-            if (mask)
+            if (transparencyMode == TransparencyMode.Mask)
             {
                 return GenerateAtlas(sprites, out spriteData, cols, rows, textureSettings.transparentColor, baseTwo);
             }


### PR DESCRIPTION
### Empty Tile Behaviour
Added option to remove empty (fully transparent) tiles in 'Tileset (Grid)' mode.
It has 3 modes:
- Keep: Same as old functionality - keeps all empty tiles.
- Index: Removes all empty tiles, but indexes them (in names), so if a tile is changed to be no longer empty, references are still consistent.
- Remove: Completely remove

s all empty tiles - treats them as if they never existed.

### Transparency Modes
Expanded the functionality of the transparency mask, with 3 modes:
- Disabled: Same functionality as if the mask were disabled
- Alpha: Uses alpha as transparency
- Mask: Use mask colour - as if mask were enabled